### PR TITLE
getCampaignLogCounts() Inner to Left Join for performance gain on campaign page

### DIFF
--- a/scripts/core-patches.sh
+++ b/scripts/core-patches.sh
@@ -100,3 +100,8 @@ echo "----------------------------------------------------"
 echo "[Bug] Contact limiter threads (2.14)"
 echo "https://github.com/mautic/mautic/pull/6211"
 curl -L "https://github.com/mautic/mautic/pull/6211.diff" | git apply -v
+
+# getCampaignLogCounts() Inner to Left Join for performance gain on campaign page
+echo ; echo "Inner to Left Join for performance gain on campaign page #6214"
+echo "https://github.com/mautic/mautic/pull/6214"
+curl -L "https://github.com/mautic/mautic/pull/6214.diff" | git apply -v


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Automated tests included? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Change an InnerJoin to a Left Join because its faster. Shouldnt affect results - might even make the log counts more accurate because it wont drop event-lead records that were processed despite being dropped from the campaign after the fact.


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. 
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 