### PR TITLE
APC bug within Custom Field validator

### DIFF
--- a/scripts/core-patches.sh
+++ b/scripts/core-patches.sh
@@ -118,3 +118,9 @@ curl -L "https://gist.githubusercontent.com/heathdutton/5ed0edc0a3dd7dd77eb478a9
 echo "----------------------------------------------------"
 echo "Disable the contacts view embedded in campaign view (temporary)."
 curl -L "https://gist.githubusercontent.com/heathdutton/27065426ff16f2b0834a550d8a27aa76/raw/d5adf30362260cff97e7e1064ff65c36b1e3794b/contact_list_disable.diff" | git apply -v
+
+# Fixes CORE LeadField APC error within custom field validator closure
+echo "----------------------------------------------------"
+echo "Fixes CORE LeadField APC error within custom field validator closure #6254"
+echo "https://github.com/mautic/mautic/pull/6254"
+curl -L "https://github.com/mautic/mautic/pull/6254.diff" | git apply -v


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | YES
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Fixes bug introduced in Core that got triggered when APC was enabled:
` mautic.CRITICAL: Uncaught PHP Exception Exception: "Serialization of 'Closure' is not allowed" at /var/app/current/vendor/symfony/validator/Mapping/Cache/ApcCache.php line 55 {"exception":"[object] (Exception(code: 0): Serialization of 'Closure' is not allowed at /var/app/current/vendor/symfony/validator/Mapping/Cache/ApcCache.php:55)"}`

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. enable APC, APCu
2. save a custom field

#### Steps to test this PR:
1. enable APC, APCu
2. save a custom field
2b. Alternately, save a custom field that violates the alias unique string constraint

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 