### PR TITLE
[ENG-377] move ReportEvents::REPORT_QUERY_PRE_EXECUTE to dispatch ear…

### DIFF
--- a/scripts/core-patches.sh
+++ b/scripts/core-patches.sh
@@ -105,3 +105,9 @@ curl -L "https://gist.githubusercontent.com/cykonetic/dd517bc45f633c00f2435e4c8f
 echo "----------------------------------------------------"
 echo "Converts United States proper names to abbreviations"
 curl -L "https://gist.githubusercontent.com/cykonetic/521b38133797e2a3f48060c519a1870e/raw/6e4a04d3e7202b66c437fff3234c900c073d3441/stateacceptancepatch.diff" | git apply -v
+
+# Report Event Dispatch called earlier to prevent fatal error when pagination used
+echo "----------------------------------------------------"
+echo "Report Event Dispatch called earlier to prevent fatal error when pagination used"
+echo "https://github.com/mautic/mautic/pull/6330"
+curl -L "https://github.com/mautic/mautic/pull/6330.diff" | git apply -v


### PR DESCRIPTION
…lier to prevent error on pagination execution query

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Pagination query on reports fails because the event dispatch to handle extended fields occurred to late.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. 
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 