### PR TITLE
[ENG-411] login screen takes geologic age: up the cache timeout to 30

### DIFF
--- a/mautic_eb/app/config/parameters_local.php
+++ b/mautic_eb/app/config/parameters_local.php
@@ -30,6 +30,7 @@ $parameters = [
     'tmp_path'          => '/tmp',
     // Support the cache path for "ondeck" during deployment, switching to "current" when there.
     'cache_path'        => str_replace('/mautic_eb/app/config', '/mautic/app/cache', __DIR__),
+    'cached_data_timeout' => '30',
 ];
 
 /**


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | N
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Increase the cache-timeout to 30 mins to reduce instance of lagging login.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. 
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 