### PR TITLE
[ENG-828] Upgrade plugins on deployment.

### DIFF
--- a/.ebextensions/70_mautic.config
+++ b/.ebextensions/70_mautic.config
@@ -20,10 +20,10 @@ container_commands:
     command: console doctrine:migrations:migrate --no-interaction --allow-no-migration -vvv
     ignoreErrors: true
     leader_only: true
-  # Force schema updates for custom plugins that have no migrations.
-  # 74_mautic_schema:
-  #  command: console doctrine:schema:update --force -vvv
-  #  leader_only: true
+  # Force schema updates for custom plugins (versions must iterate).
+  74_mautic_plugins:
+    command: console mautic:plugins:reload -vvv
+    leader_only: true
   # Download IP Lookup databases, which are stored in each instance and not on the EFS mount.
   75_mautic_iplookup:
     command: console mautic:iplookup:download -vvv


### PR DESCRIPTION
This avoids a manual step of going to the plugins screen and clicking “upgrade/install”.

This command did not exist prior to 2.14.0