### PR TITLE
[ENG-914] remove warning about missing $groupBy

### DIFF
--- a/scripts/patches/6651.diff
+++ b/scripts/patches/6651.diff
@@ -1422,12 +1422,12 @@ index 123ca3e967..4c385a7f0a 100644
              //the number of entities are now less then the current page so redirect to the last page
              $lastPage = ($count === 1) ? 1 : (ceil($count / $limit)) ?: 1;
 diff --git a/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php b/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
-index bc2a199b7c..a7e0c3e68c 100644
+index 6953838ea2..0f2c50b231 100644
 --- a/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
 +++ b/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
-@@ -49,19 +49,22 @@ public function getEntitiesWithCustomFields($object, $args, $resultsCallback = n
+@@ -49,22 +49,25 @@ public function getEntitiesWithCustomFields($object, $args, $resultsCallback = n
          $this->buildWhereClause($dq, $args);
- 
+
          // Distinct is required here to get the correct count when group by is used due to applied filters
 -        $countSelect = ($this->useDistinctCount) ? 'COUNT(DISTINCT('.$this->getTableAlias().'.id))' : 'COUNT('.$this->getTableAlias().'.id)';
 -        $dq->select($countSelect.' as count');
@@ -1440,7 +1440,7 @@ index bc2a199b7c..a7e0c3e68c 100644
 +            if ($groupBy = $dq->getQueryPart('groupBy')) {
 +                $dq->resetQueryPart('groupBy');
 +            }
- 
+
 -        // Advanced search filters may have set a group by and if so, let's remove it for the count.
 -        if ($groupBy = $dq->getQueryPart('groupBy')) {
 -            $dq->resetQueryPart('groupBy');
@@ -1448,7 +1448,7 @@ index bc2a199b7c..a7e0c3e68c 100644
 +            $result = $dq->execute()->fetchAll();
 +            $total  = ($result) ? $result[0]['count'] : 0;
          }
- 
+
 -        //get a total count
 -        $result = $dq->execute()->fetchAll();
 -        $total  = ($result) ? $result[0]['count'] : 0;
@@ -1457,7 +1457,11 @@ index bc2a199b7c..a7e0c3e68c 100644
 +        if (!$total && !empty($args['withTotalCount'])) {
              $results = [];
          } else {
-             if ($groupBy) {
+-            if ($groupBy) {
++            if (isset($groupBy) && $groupBy) {
+                 $dq->groupBy($groupBy);
+             }
+             //now get the actual paginated results
 diff --git a/app/bundles/LeadBundle/Entity/LeadRepository.php b/app/bundles/LeadBundle/Entity/LeadRepository.php
 index 5176ce7403..41617e56ab 100755
 --- a/app/bundles/LeadBundle/Entity/LeadRepository.php


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | YES
| New feature? | NO
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

We introduced a nosiy warning message with a missing var. This fixes that.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. 
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 